### PR TITLE
fix(build-and-deploy): deprecate set-output command

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -111,8 +111,10 @@ jobs:
         echo "IMAGE_NAME_WITH_SHA=$IMG:${{ inputs.tagPrefix }}${TAG_SHA::8}" >> $GITHUB_ENV
         echo "IMAGE_NAME_FULL_SHA=$IMG:${{ inputs.tagPrefix }}${TAG_SHA}" >> $GITHUB_ENV
         echo '::echo::on'
-        echo "::set-output name=IMAGE_NAME_WITH_SHA::$IMG:${{ inputs.tagPrefix }}${TAG_SHA::8}"
-        echo "::set-output name=IMAGE_NAME_FULL_SHA::$IMG:${{ inputs.tagPrefix }}${TAG_SHA}"
+        # echo "::set-output name=IMAGE_NAME_WITH_SHA::$IMG:${{ inputs.tagPrefix }}${TAG_SHA::8}"
+        echo "IMAGE_NAME_WITH_SHA=$IMG:${{ inputs.tagPrefix }}${TAG_SHA::8}" >> $GITHUB_OUTPUT
+        # echo "::set-output name=IMAGE_NAME_FULL_SHA::$IMG:${{ inputs.tagPrefix }}${TAG_SHA}"
+        echo "IMAGE_NAME_FULL_SHA=$IMG:${{ inputs.tagPrefix }}${TAG_SHA}" >> $GITHUB_OUTPUT
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2.1.0


### PR DESCRIPTION
## What does this PR do?

[GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

before the fix 👇🏻 
![image](https://github.com/firefliesai/.github/assets/10423301/ffb83d45-3830-429f-8b46-58f20a19f234)

after the fix 👇🏻 
![image](https://github.com/firefliesai/.github/assets/10423301/89f77f7f-9218-4461-ac9f-5d93756a6882)


## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes
