### PR TITLE
add updated gitflow-release action

### DIFF
--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -45,5 +45,9 @@ export default async ({ core, context, github, pull_numbers_in_release, latest_r
   else if (bumpType === 1) minor += 1;
   else patch += 1;
   version = `${major}.${minor}.${patch}`;
+
+  console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
+  console.log(`Release summary:\n${releaseSummary}`);
+
   return { releaseSummary, version };
 };

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -1,20 +1,8 @@
 // @ts-check
-/** @param {import('github-script').AsyncFunctionArguments & { pull_number: number, pull_numbers_in_release: string }} AsyncFunctionArguments */
-export default async ({ core, context, github, pull_number, pull_numbers_in_release }) => {
+/** @param {import('github-script').AsyncFunctionArguments & { pull_number: number, pull_numbers_in_release: string, latest_release_tag_name?: string }} AsyncFunctionArguments */
+export default async ({ core, context, github, pull_numbers_in_release, latest_release_tag_name }) => {
   const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
   
-  const pr = await github.rest.pulls.get({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number,
-  });
- 
-  const body = pr.data.body;
-  if (!body) {
-    core.setFailed("No PR body");
-    return;
-  }
-
   // Get the PRs and parse the release summary
   const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
     const pr = await github.rest.pulls.get({
@@ -22,24 +10,40 @@ export default async ({ core, context, github, pull_number, pull_numbers_in_rele
       repo: context.repo.repo,
       pull_number: prNumber
     });
-    if (!pr.data.body) {
+    const body = pr.data.body;
+    if (!body) {
       return;
     }
     const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-    let match = regex.exec(pr.data.body)?.[1]?.trim();
-    // try to remove empty lines
+    let match = regex.exec(body)?.[1]?.trim();
+    
+    // try to remove empty lines and format bullets
     match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
       s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
     ).join('\n');
-    return `${pr.data.title}\n${match}`;
-  })).then((prs) => prs.filter(Boolean));
-  const releaseSummary = mergedPrs.join('\n\n');
 
-  // Update the PR body
-  await github.rest.pulls.update({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number,
-    body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
-  });
+    let type = 0 // patch
+    if (body.includes("[x] Feature")) {
+      type = 1 // minor
+    }
+
+    return {
+      title: pr.data.title,
+      summary: match,
+      type,
+    }
+  })).then((prs) => prs.filter(pr => !!pr));
+  
+  const releaseSummary = mergedPrs.map((pr) => {
+    return `${pr.title}\n${pr.summary}`;
+  }).join('\n\n');
+
+  let version = latest_release_tag_name || "0.0.0";
+  const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
+  let [major, minor, patch] = version.split('.').map(Number);
+  if (bumpType === 2) major += 1;
+  else if (bumpType === 1) minor += 1;
+  else patch += 1;
+  version = `${major}.${minor}.${patch}`;
+  return { releaseSummary, version };
 };

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -26,10 +26,14 @@ export default async ({ core, context, github, pull_number, pull_numbers_in_rele
       return;
     }
     const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-    const match = regex.exec(pr.data.body)
-    return match?.[1]?.trim();
+    let match = regex.exec(pr.data.body)?.[1]?.trim();
+    // try to remove empty lines
+    match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
+      s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
+    ).join('\n');
+    return `${pr.data.title}\n${match}`;
   })).then((prs) => prs.filter(Boolean));
-  const releaseSummary = mergedPrs.map(pr => pr?.includes("\n") ? pr : `* ${pr}`).join('\n');
+  const releaseSummary = mergedPrs.join('\n');
 
   // Update the PR body
   await github.rest.pulls.update({
@@ -38,5 +42,4 @@ export default async ({ core, context, github, pull_number, pull_numbers_in_rele
     pull_number,
     body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
   });
-
 };

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -33,7 +33,7 @@ export default async ({ core, context, github, pull_number, pull_numbers_in_rele
     ).join('\n');
     return `${pr.data.title}\n${match}`;
   })).then((prs) => prs.filter(Boolean));
-  const releaseSummary = mergedPrs.join('\n');
+  const releaseSummary = mergedPrs.join('\n\n');
 
   // Update the PR body
   await github.rest.pulls.update({

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -1,53 +1,59 @@
 // @ts-check
 /** @param {import('github-script').AsyncFunctionArguments & { pull_number: number, pull_numbers_in_release: string, latest_release_tag_name?: string }} AsyncFunctionArguments */
 export default async ({ core, context, github, pull_numbers_in_release, latest_release_tag_name }) => {
-  const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
-  
-  // Get the PRs and parse the release summary
-  const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
-    const pr = await github.rest.pulls.get({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: prNumber
-    });
-    const body = pr.data.body;
-    if (!body) {
-      return;
-    }
-    const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-    let match = regex.exec(body)?.[1]?.trim();
+  try {
+    const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
     
-    // try to remove empty lines and format bullets
-    match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
-      s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
-    ).join('\n');
+    // Get the PRs and parse the release summary
+    const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+      const pr = await github.rest.pulls.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: prNumber
+      });
+      const body = pr.data.body;
+      if (!body) {
+        return;
+      }
+      const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+      let match = regex.exec(body)?.[1]?.trim();
+      
+      // try to remove empty lines and format bullets
+      match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
+        s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
+      ).join('\n');
 
-    let type = 0 // patch
-    if (body.includes("[x] Feature")) {
-      type = 1 // minor
-    }
+      let type = 0 // patch
+      if (body.includes("[x] Feature")) {
+        type = 1 // minor
+      }
 
-    return {
-      title: pr.data.title,
-      summary: match,
-      type,
-    }
-  })).then((prs) => prs.filter(pr => !!pr));
-  
-  const releaseSummary = mergedPrs.map((pr) => {
-    return `${pr.title}\n${pr.summary}`;
-  }).join('\n\n');
+      return {
+        title: pr.data.title,
+        summary: match,
+        type,
+      }
+    })).then((prs) => prs.filter(pr => !!pr));
+    
+    const releaseSummary = mergedPrs.map((pr) => {
+      return `${pr.title}\n${pr.summary}`;
+    }).join('\n\n');
 
-  let version = latest_release_tag_name || "0.0.0";
-  const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
-  let [major, minor, patch] = version.split('.').map(Number);
-  if (bumpType === 2) major += 1;
-  else if (bumpType === 1) minor += 1;
-  else patch += 1;
-  version = `${major}.${minor}.${patch}`;
+    let version = latest_release_tag_name || "0.0.0";
+    const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
+    let [major, minor, patch] = version.split('.').map(Number);
+    if (bumpType === 2) major += 1;
+    else if (bumpType === 1) minor += 1;
+    else patch += 1;
+    version = `${major}.${minor}.${patch}`;
 
-  console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
-  console.log(`Release summary:\n${releaseSummary}`);
+    console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
+    console.log(`Release summary:\n${releaseSummary}`);
 
-  return { releaseSummary, version };
+    core.setOutput('release_summary', releaseSummary);
+    core.setOutput('version', version);
+  } catch (error) {
+    console.log(`Could not determine release summary and version`)
+    console.log(error)
+  }
 };

--- a/.github/scripts/gitflow-release.js
+++ b/.github/scripts/gitflow-release.js
@@ -1,0 +1,42 @@
+// @ts-check
+/** @param {import('github-script').AsyncFunctionArguments & { pull_number: number, pull_numbers_in_release: string }} AsyncFunctionArguments */
+export default async ({ core, context, github, pull_number, pull_numbers_in_release }) => {
+  const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
+  
+  const pr = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number,
+  });
+ 
+  const body = pr.data.body;
+  if (!body) {
+    core.setFailed("No PR body");
+    return;
+  }
+
+  // Get the PRs and parse the release summary
+  const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+    const pr = await github.rest.pulls.get({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: prNumber
+    });
+    if (!pr.data.body) {
+      return;
+    }
+    const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+    const match = regex.exec(pr.data.body)
+    return match?.[1]?.trim();
+  })).then((prs) => prs.filter(Boolean));
+  const releaseSummary = mergedPrs.map(pr => pr?.includes("\n") ? pr : `* ${pr}`).join('\n');
+
+  // Update the PR body
+  await github.rest.pulls.update({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number,
+    body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
+  });
+
+};

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@types/github-script": "github:actions/github-script"
+  }
+}

--- a/.github/workflows/gitflow-create-release.yml
+++ b/.github/workflows/gitflow-create-release.yml
@@ -1,3 +1,5 @@
+# DEPRECATED - USE gitflow-release instead
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/gitflow-create-release.yml
+++ b/.github/workflows/gitflow-create-release.yml
@@ -22,7 +22,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: hoangvvo/gitflow-workflow-action@0.2.4
+      - uses: hoangvvo/gitflow-workflow-action@0.3.3
         with:
           version: ${{ inputs.version }}
           develop_branch: ${{ inputs.develop_branch }}

--- a/.github/workflows/gitflow-post-release.yml
+++ b/.github/workflows/gitflow-post-release.yml
@@ -1,3 +1,5 @@
+# DEPRECATED - USE gitflow-release instead
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/gitflow-post-release.yml
+++ b/.github/workflows/gitflow-post-release.yml
@@ -17,7 +17,7 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: hoangvvo/gitflow-workflow-action@0.2.4
+      - uses: hoangvvo/gitflow-workflow-action@0.3.3
         with:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -31,6 +31,8 @@ jobs:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
           dry_run: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: generate_pr_summary
         name: generate PR summary

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ steps.release_workflow_dry_run.outputs.type == 'release' && steps.release_workflow_dry_run.outputs.pull_numbers_in_release }}
         uses: actions/github-script@v7
         with:
-          scripts: |
+          script: |
             const pull_numbers_in_release = '${{ steps.release_workflow_dry_run.outputs.pull_numbers_in_release }}';
             const latest_release_tag_name = '${{ steps.release_workflow_dry_run.outputs.latest_release_tag_name }}';
 

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -115,7 +115,7 @@ jobs:
               ).join('\n');
               return `${pr.data.title}\n${match}`;
             })).then((prs) => prs.filter(Boolean));
-            const releaseSummary = mergedPrs.join('\n');
+            const releaseSummary = mergedPrs.join('\n\n');
 
             // Update the PR body
             await github.rest.pulls.update({

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -1,0 +1,116 @@
+on:
+  workflow_call:
+    inputs:
+      develop_branch:
+        required: true
+        type: string
+        description: "Staging branch"
+
+      main_branch:
+        required: true
+        type: string
+        description: "Production branch"
+
+      version:
+        required: false
+        type: string
+        description: "Version to release"
+
+      merge_back_from_main:
+        required: false
+        type: string
+        description: "Merge back from main to develop"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - id: release_workflow
+        uses: hoangvvo/gitflow-workflow-action@0.3.2
+        with:
+          version: ${{ inputs.version }}
+          develop_branch: ${{ inputs.develop_branch }}
+          main_branch: ${{ inputs.main_branch }}
+          merge_back_from_main: ${{ inputs.merge_back_from_main }}
+          slack: >
+            {
+              "channel": "feature-rollout",
+              "username_mapping": {
+                "hoangvvo": "U03B3E4UPV3",
+                "dmkorb": "U0256NC37GT",
+                "samuelayo": "UFHCU47B6",
+                "sudotong": "U04KDQACM",
+                "greguintow": "U02DDCN2UDC",
+                "debloper": "USG05RE76",
+                "jhho89": "U01HB1J09PF",
+                "rogerpadilla": "U02FR157SG1",
+                "grimmer0125": "U03BZH4CYBD",
+                "dirathea": "U028RKKSNTW",
+                "thadeuk": "U02G82H7QR2",
+                "atomicman57": "U8EGXN80Z",
+                "rgautam98": "U03AAU48XL3",
+                "Riddhish97": "U04H6BQ6V0T",
+                "azka-01": "U0258AV7R3M",
+                "longyarnz": "UH8DQ3PRA",
+                "ProKashif": "U01GUG3L4D6",
+                "Lutif": "U01N11L5BD0",
+                "FatimahAbdullah": "U0277DZ97JL",
+                "Nilomiranda": "U02GNJGBPJ7",
+                "ugokoli": "U01378G4H28",
+                "MrMuhammadAbdullah1704": "U01G1J5HYG5",
+                "sumitkolhe": "U04PZD94TAR",
+                "carloscdante": "U04FY3MGBV4",
+                "wilforlan": "UC0UWLSQ2",
+                "anooppoommen": "U038VBD2XCP",
+                "hamidladan": "U043NHY5HNF",
+                "zypher606": "U021VD0J2UE",
+                "samuelfruhauf": "U02M3F53PU7",
+                "MBilal07": "U022EQJQBMF",
+                "shivamluthra": "U043X0VCASE",
+                "haziqAhmed92": "U02HAU99A1G",
+                "htkimura": "U061P10ADNV"
+              }
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+      - name: Prefill release summary
+        if: ${{ steps.release_workflow.outputs.type == 'release' && steps.release_workflow.outputs.pull_number && steps.release_workflow.outputs.pull_numbers_in_release }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
+
+            const mergedPrNumbers = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}".split(',').map(Number);
+            const body = context.payload.pull_request.body;
+
+            // Get the PRs and parse the release summary
+            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              const regex = /## What does this PR do\?\n\n(.*?)\n\n##/s;
+              if (!pr.data.body) {
+                return;
+              }
+              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+              const match = regex.exec(pr.data.body)
+              return match?.[1]?.trim();
+            })).then((prs) => prs.filter(Boolean));
+            const releaseSummary = mergedPrs.join('\n');
+
+            // Update the PR body
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+              body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
+            });

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -80,9 +80,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
-            const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";
-
             const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
 
             const pr = await github.rest.pulls.get({
@@ -108,10 +105,14 @@ jobs:
                 return;
               }
               const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-              const match = regex.exec(pr.data.body)
-              return match?.[1]?.trim();
+              let match = regex.exec(pr.data.body)?.[1]?.trim();
+              // try to remove empty lines
+              match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
+                s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
+              ).join('\n');
+              return `${pr.data.title}\n${match}`;
             })).then((prs) => prs.filter(Boolean));
-            const releaseSummary = mergedPrs.map(pr => pr?.includes("\n") ? pr : `* ${pr}`).join('\n');
+            const releaseSummary = mergedPrs.join('\n');
 
             // Update the PR body
             await github.rest.pulls.update({

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -80,6 +80,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
+            const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";
+
             const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
 
             const pr = await github.rest.pulls.get({

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: release_workflow
-        uses: hoangvvo/gitflow-workflow-action@0.3.2
+        uses: hoangvvo/gitflow-workflow-action@0.3.3
         with:
           version: ${{ inputs.version }}
           develop_branch: ${{ inputs.develop_branch }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -80,36 +80,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const script = require('${{ github.workspace }}/firefliesai/.github/scripts/gitflow-release.js');
+
             const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number,
-            });
+            const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";
 
-            const mergedPrNumbers = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}".split(',').map(Number);
-            const body = context.payload.pull_request.body;
-
-            // Get the PRs and parse the release summary
-            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-              if (!pr.data.body) {
-                return;
-              }
-              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-              const match = regex.exec(pr.data.body)
-              return match?.[1]?.trim();
-            })).then((prs) => prs.filter(Boolean));
-            const releaseSummary = mergedPrs.map(pr => pr.includes("\n") ? pr : `* ${pr}`).join('\n');
-
-            // Update the PR body
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number,
-              body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
-            });
+            await script({github, context, core, pull_number, pull_numbers_in_release})

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -97,7 +97,6 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: prNumber
               });
-              const regex = /## What does this PR do\?\n\n(.*?)\n\n##/s;
               if (!pr.data.body) {
                 return;
               }

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -105,7 +105,7 @@ jobs:
               const match = regex.exec(pr.data.body)
               return match?.[1]?.trim();
             })).then((prs) => prs.filter(Boolean));
-            const releaseSummary = mergedPrs.join('\n');
+            const releaseSummary = mergedPrs.map(pr => pr.includes("\n") ? pr : `* ${pr}`).join('\n');
 
             // Update the PR body
             await github.rest.pulls.update({

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -43,55 +43,61 @@ jobs:
             const pull_numbers_in_release = '${{ steps.release_workflow_dry_run.outputs.pull_numbers_in_release }}';
             const latest_release_tag_name = '${{ steps.release_workflow_dry_run.outputs.latest_release_tag_name }}';
 
-            const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
-
-            // Get the PRs and parse the release summary
-            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-              const body = pr.data.body;
-              if (!body) {
-                return;
-              }
-              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-              let match = regex.exec(body)?.[1]?.trim();
+            try {
+              const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
               
-              // try to remove empty lines and format bullets
-              match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
-                s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
-              ).join('\n');
+              // Get the PRs and parse the release summary
+              const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+                const pr = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber
+                });
+                const body = pr.data.body;
+                if (!body) {
+                  return;
+                }
+                const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+                let match = regex.exec(body)?.[1]?.trim();
+                
+                // try to remove empty lines and format bullets
+                match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
+                  s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
+                ).join('\n');
 
-              let type = 0 // patch
-              if (body.includes("[x] Feature")) {
-                type = 1 // minor
-              }
+                let type = 0 // patch
+                if (body.includes("[x] Feature")) {
+                  type = 1 // minor
+                }
 
-              return {
-                title: pr.data.title,
-                summary: match,
-                type,
-              }
-            })).then((prs) => prs.filter(pr => !!pr));
+                return {
+                  title: pr.data.title,
+                  summary: match,
+                  type,
+                }
+              })).then((prs) => prs.filter(pr => !!pr));
+              
+              const releaseSummary = mergedPrs.map((pr) => {
+                return `${pr.title}\n${pr.summary}`;
+              }).join('\n\n');
 
-            const releaseSummary = mergedPrs.map((pr) => {
-              return `${pr.title}\n${pr.summary}`;
-            }).join('\n\n');
+              let version = latest_release_tag_name || "0.0.0";
+              const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
+              let [major, minor, patch] = version.split('.').map(Number);
+              if (bumpType === 2) major += 1;
+              else if (bumpType === 1) minor += 1;
+              else patch += 1;
+              version = `${major}.${minor}.${patch}`;
 
-            let version = latest_release_tag_name || "0.0.0";
-            const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
-            let [major, minor, patch] = version.split('.').map(Number);
-            if (bumpType === 2) major += 1;
-            else if (bumpType === 1) minor += 1;
-            else patch += 1;
-            version = `${major}.${minor}.${patch}`;
+              console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
+              console.log(`Release summary:\n${releaseSummary}`);
 
-            console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
-            console.log(`Release summary:\n${releaseSummary}`);
-
-            return { releaseSummary, version };
+              core.setOutput('release_summary', releaseSummary);
+              core.setOutput('version', version);
+            } catch (error) {
+              console.log(`Could not determine release summary and version`)
+              console.log(error)
+            }
 
       - id: release_workflow
         uses: hoangvvo/gitflow-workflow-action@0.3.5
@@ -100,7 +106,7 @@ jobs:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
           merge_back_from_main: ${{ inputs.merge_back_from_main }}
-          release_summary: ${{ fromJSON(steps.generate_pr_summary.outputs.result).releaseSummary }}
+          release_summary: ${{ steps.generate_pr_summary.outputs.release_summary }}
           slack: >
             {
               "channel": "feature-rollout",
@@ -143,4 +149,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          VERSION: ${{ fromJSON(steps.generate_pr_summary.outputs.result).version }}
+          VERSION: ${{ steps.generate_pr_summary.outputs.version }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -87,6 +87,10 @@ jobs:
             else if (bumpType === 1) minor += 1;
             else patch += 1;
             version = `${major}.${minor}.${patch}`;
+
+            console.log(`Determined suggested version: ${version} (${['patch', 'minor', 'major'][bumpType]})`)
+            console.log(`Release summary:\n${releaseSummary}`);
+
             return { releaseSummary, version };
 
       - id: release_workflow

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -25,6 +25,65 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - id: release_workflow_dry_run
+        uses: hoangvvo/gitflow-workflow-action@0.3.3
+        with:
+          develop_branch: ${{ inputs.develop_branch }}
+          main_branch: ${{ inputs.main_branch }}
+          dry_run: "true"
+
+      - id: generate_pr_summary
+        name: generate PR summary
+        if: ${{ steps.release_workflow_dry_run.outputs.type == 'release' && steps.release_workflow_dry_run.outputs.pull_numbers_in_release }}
+        uses: actions/github-script@v7
+        with:
+          scripts: |
+            const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
+
+            // Get the PRs and parse the release summary
+            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              const body = pr.data.body;
+              if (!body) {
+                return;
+              }
+              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+              let match = regex.exec(body)?.[1]?.trim();
+              
+              // try to remove empty lines and format bullets
+              match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
+                s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
+              ).join('\n');
+
+              let type = 0 // patch
+              if (body.includes("[x] Feature")) {
+                type = 1 // minor
+              }
+
+              return {
+                title: pr.data.title,
+                summary: match,
+                type,
+              }
+            })).then((prs) => prs.filter(pr => !!pr));
+
+            const releaseSummary = mergedPrs.map((pr) => {
+              return `${pr.title}\n${pr.summary}`;
+            }).join('\n\n');
+
+            let version = latest_release_tag_name || "0.0.0";
+            const bumpType = Math.max(...mergedPrs.map((pr) => pr.type));
+            let [major, minor, patch] = version.split('.').map(Number);
+            if (bumpType === 2) major += 1;
+            else if (bumpType === 1) minor += 1;
+            else patch += 1;
+            version = `${major}.${minor}.${patch}`;
+            return { releaseSummary, version };
+
       - id: release_workflow
         uses: hoangvvo/gitflow-workflow-action@0.3.3
         with:
@@ -32,6 +91,7 @@ jobs:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
           merge_back_from_main: ${{ inputs.merge_back_from_main }}
+          release_summary: ${{ steps.generate_pr_summary.outputs.releaseSummary }}
           slack: >
             {
               "channel": "feature-rollout",
@@ -74,53 +134,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-
-      - name: Prefill release summary
-        if: ${{ steps.release_workflow.outputs.type == 'release' && steps.release_workflow.outputs.pull_number && steps.release_workflow.outputs.pull_numbers_in_release }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
-            const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";
-
-            const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
-
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number,
-            });
-
-            const body = pr.data.body;
-            if (!body) {
-              core.setFailed("No PR body");
-              return;
-            }
-
-            // Get the PRs and parse the release summary
-            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-              if (!pr.data.body) {
-                return;
-              }
-              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
-              let match = regex.exec(pr.data.body)?.[1]?.trim();
-              // try to remove empty lines
-              match = match?.split('\n').map(s => s.trim()).filter(Boolean).map(
-                s => s.startsWith('-') || s.startsWith('*') ? s : `* ${s}`
-              ).join('\n');
-              return `${pr.data.title}\n${match}`;
-            })).then((prs) => prs.filter(Boolean));
-            const releaseSummary = mergedPrs.join('\n\n');
-
-            // Update the PR body
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number,
-              body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
-            });
+          VERSION: ${{ steps.generate_pr_summary.outputs.version }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -19,7 +19,7 @@ on:
       merge_back_from_main:
         required: false
         type: string
-        description: "Merge back from main to develop"
+        description: "Merge back from production branch instead of release branch to staging branch"
 
 jobs:
   release:

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: release_workflow_dry_run
-        uses: hoangvvo/gitflow-workflow-action@0.3.3
+        uses: hoangvvo/gitflow-workflow-action@0.3.5
         with:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
@@ -38,6 +38,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           scripts: |
+            const pull_numbers_in_release = '${{ steps.release_workflow_dry_run.outputs.pull_numbers_in_release }}';
+            const latest_release_tag_name = '${{ steps.release_workflow_dry_run.outputs.latest_release_tag_name }}';
+
             const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
 
             // Get the PRs and parse the release summary
@@ -85,7 +88,7 @@ jobs:
             return { releaseSummary, version };
 
       - id: release_workflow
-        uses: hoangvvo/gitflow-workflow-action@0.3.3
+        uses: hoangvvo/gitflow-workflow-action@0.3.5
         with:
           version: ${{ inputs.version }}
           develop_branch: ${{ inputs.develop_branch }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -100,7 +100,7 @@ jobs:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
           merge_back_from_main: ${{ inputs.merge_back_from_main }}
-          release_summary: ${{ steps.generate_pr_summary.outputs.releaseSummary }}
+          release_summary: ${{ fromJSON(steps.generate_pr_summary.outputs.result).releaseSummary }}
           slack: >
             {
               "channel": "feature-rollout",
@@ -143,4 +143,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-          VERSION: ${{ steps.generate_pr_summary.outputs.version }}
+          VERSION: ${{ fromJSON(steps.generate_pr_summary.outputs.result).version }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -80,9 +80,43 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const script = require('${{ github.workspace }}/.github/scripts/gitflow-release.js');
-
             const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
             const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";
 
-            await script({github, context, core, pull_number, pull_numbers_in_release})
+            const mergedPrNumbers = Array.from(new Set(pull_numbers_in_release.split(',').map(Number)));
+
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
+
+            const body = pr.data.body;
+            if (!body) {
+              core.setFailed("No PR body");
+              return;
+            }
+
+            // Get the PRs and parse the release summary
+            const mergedPrs = await Promise.all(mergedPrNumbers.map(async (prNumber) => {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (!pr.data.body) {
+                return;
+              }
+              const regex = /\#\# What does this PR do\?([\s\S]*?)\n\#\#/gm;
+              const match = regex.exec(pr.data.body)
+              return match?.[1]?.trim();
+            })).then((prs) => prs.filter(Boolean));
+            const releaseSummary = mergedPrs.map(pr => pr?.includes("\n") ? pr : `* ${pr}`).join('\n');
+
+            // Update the PR body
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+              body: body.replace("## Release summary", `## Release summary\n\n${releaseSummary}`)
+            });

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const script = require('${{ github.workspace }}/firefliesai/.github/scripts/gitflow-release.js');
+            const script = require('${{ github.workspace }}/.github/scripts/gitflow-release.js');
 
             const pull_number = ${{ steps.release_workflow.outputs.pull_number }};
             const pull_numbers_in_release = "${{ steps.release_workflow.outputs.pull_numbers_in_release }}";


### PR DESCRIPTION
## What does this PR do?

Add the updated [git-flow release action](https://github.com/hoangvvo/gitflow-workflow-action). 

- simplifies the setup so that we only need one workflow file added to each repo instead of two like before
- auto-extract the "What does this PR do?" sections from each PR of the release and add it to the Release summary section

Check out the notion doc to see the updated setup instruction: https://www.notion.so/fireflies/Automate-release-changelog-and-announcement-daf14aa131974cb291212e544359d018

## Type of change

This pull request is a
- [x] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
