### PR TITLE
Allow to set trigger token

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -15,6 +15,9 @@ on:
         default: 'main'
         required: false
         type: string
+      trigger_token:
+        required: false
+        type: string
 
 jobs:
   create_deployment:
@@ -32,11 +35,17 @@ jobs:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/scripts/auto_release.js
+
+      - name: Add Trigger Token to env
+        run: |
+          $token = ${{ inputs.trigger_token }} || ${{ secrets.GITHUB_TOKEN }}
+          echo "TRIGGER_TOKEN=$token" >> $GITHUB_ENV
+
       - name: Create deployment PR
         id: deploy
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ env.TRIGGER_TOKEN }}
           script: |
             const script = require('${{ github.workspace }}/firefliesai/.github/scripts/auto_release.js');
 


### PR DESCRIPTION
## What does this PR do?

- Allow to set trigger token, so `fireflies-bot` can be used

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes


## Any background context you want to provide beyond Shortcut?

When a deploy pull request is opened by `github-actions` bot, it sometimes might not run github actions as the nature of the bot, but if we run with fireflies-bot would work as is like a githtub user

[Slack thread](https://firefliesapp.slack.com/archives/CKZF9G804/p1712867901044479?thread_ts=1712862463.889359&cid=CKZF9G804)