### PR TITLE
refactor: update script to add a Github comment only when necessary

### DIFF
--- a/.github/scripts/PR_reviewer.js
+++ b/.github/scripts/PR_reviewer.js
@@ -97,8 +97,8 @@ module.exports = {
 				max_tokens: 2048,
 			}))?.choices[0].message.content;
 			const review = `${reviewTitle}\n${reviewDescription}`;
-			await commentPR({ octokit, context, issueId: pullRequest, comment: review });
 			if (!review.includes('The description does not mention any changes related to authentication or authorization')) {
+				await commentPR({ octokit, context, issueId: pullRequest, comment: review });
 				await notifySlack({
 					context,
 					sectionTitle,
@@ -110,12 +110,6 @@ module.exports = {
 			}
 		} catch (e) {
 			console.error('Error generating description review:', e);
-			await commentPR({
-				octokit,
-				context,
-				issueId: pullRequest,
-				comment: `${reviewTitle}\n**Error**: OpenAI error when reviewing the PR description.\n`,
-			});
 		}
 	}
 };


### PR DESCRIPTION
## What does this PR do?

This PR updates the script to review PR descriptions, so comments are sent to the Github PR only when necessary.

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
