### PR TITLE
chore: add cache to PR reviewer to prevent reviewing the same description again

### DIFF
--- a/.github/workflows/PR_reviewer.yml
+++ b/.github/workflows/PR_reviewer.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - name: Checkout caller-repo
         uses: actions/checkout@v4
+
       - name: Checkout firefliesai/.github
         uses: actions/checkout@v4
         with:
@@ -27,19 +28,39 @@ jobs:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/scripts/PR_reviewer.js
+
+      - name: Save PR description for caching
+        run: echo "${{ context.payload.pull_request.body }}" > ${{ github.workspace }}/firefliesai/.github/PR_description.txt
+
+      - name: Cache PR description
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/firefliesai/.github/PR_description.txt
+          key: cache-pr-${{ context.payload.pull_request.number }}-${{ hashFiles('./firefliesai/.github/PR_description.txt') }}
+
+      - name: Check cache hit
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: echo "Cache hit for PR description, skipping PR Reviewer"
+
       - name: Setup Node
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: https://npm.pkg.github.com
           scope: '@firefliesai'
+
       - name: Install packages
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           GTP_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         run: |
           [ -f package.json ] && mv package.json package.json.xx
           npm install openai @octokit/rest @slack/web-api slackify-markdown
+
       - name: Run PR Reviewer
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/github-script@v6
         id: reviewer
         env:

--- a/.github/workflows/PR_reviewer.yml
+++ b/.github/workflows/PR_reviewer.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           repository: firefliesai/.github
           path: firefliesai
-          ref: chore-sc-56296-cache-PR-description
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/scripts/PR_reviewer.js

--- a/.github/workflows/PR_reviewer.yml
+++ b/.github/workflows/PR_reviewer.yml
@@ -30,17 +30,17 @@ jobs:
           sparse-checkout: |
             .github/scripts/PR_reviewer.js
 
-      - name: Save PR description for caching
-        run: echo "${{ context.payload.pull_request.body }}" > ${{ github.workspace }}/firefliesai/.github/PR_description.txt
+      - name: Save current PR description to file
+        run: echo "${{ github.event.pull_request.body }}" > ${{ github.workspace }}/firefliesai/.github/PR_description.txt
 
-      - name: Cache PR description
+      - name: Search PR description in cache
         id: cache
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/firefliesai/.github/PR_description.txt
-          key: cache-pr-${{ context.payload.pull_request.number }}-${{ hashFiles('./firefliesai/.github/PR_description.txt') }}
+          key: cache-pr-${{ github.event.pull_request.number }}-${{ hashFiles('./firefliesai/.github/PR_description.txt') }}
 
-      - name: Check cache hit
+      - name: Cache hit
         if: steps.cache.outputs.cache-hit == 'true'
         run: echo "Cache hit for PR description, skipping PR Reviewer"
 

--- a/.github/workflows/PR_reviewer.yml
+++ b/.github/workflows/PR_reviewer.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           repository: firefliesai/.github
           path: firefliesai
+          ref: chore-sc-56296-cache-PR-description
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/scripts/PR_reviewer.js


### PR DESCRIPTION
## What does this PR do?

This PR uses a cache to skip the PR description review when the description doesn't change for the same PR between workflow executions.

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

Validated with [this temporary PR](https://github.com/firefliesai/dashboard-ff/pull/2965) on dashboard-ff.

Cache hit (skipping all next steps):
![image](https://github.com/firefliesai/.github/assets/19396161/b2b65338-e3de-41b5-83f1-2d3c3484f544)

Cache miss (runs all steps):
![image](https://github.com/firefliesai/.github/assets/19396161/ee9d5270-4493-4f8b-a1d8-c55ff848a58e)

PS: this will work only with an exact match, but this matches our daily use case

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
