### PR TITLE
Truncate release summary when too long

### DIFF
--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -85,6 +85,12 @@ jobs:
                 return `${pr.title}\n${pr.summary}`;
               }).join('\n\n');
 
+              // Truncate the release summary if it's too long
+              const maxLength = 65000; // Leaving some buffer, as max is 65536
+              if (releaseSummary.length > maxLength) {
+                releaseSummary = releaseSummary.substring(0, maxLength) + "\n\n... (truncated due to length)";
+              }
+
               const versionIncrementType = Math.max(...mergedPrs.map((pr) => pr.type));
               const versionIncrement = ['patch', 'minor', 'major'][versionIncrementType] || 'patch';
 


### PR DESCRIPTION
## What does this PR do?

Truncate release summary when too long.

For repositories that have existed for a while, the first time the release action is executed, the accumulation
of PRs from the start of the project commit is used as release summary causing a validation to fail.

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

![Screenshot 2024-07-21 at 00 50 28](https://github.com/user-attachments/assets/1aaba6a6-27d9-4a54-b750-c218e5032137)


## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
