### PR TITLE
Use gpt-4o-mini instead of gpt-4o for PR reviewer

### DIFF
--- a/.github/scripts/PR_reviewer.js
+++ b/.github/scripts/PR_reviewer.js
@@ -119,7 +119,7 @@ module.exports = {
 		try {
 			const reviewDescription = (await openai.chat.completions.create({
 				messages: [{ role: 'user', content: promptPRDescription }],
-				model: 'gpt-4o',
+				model: 'gpt-4o-mini',
 				temperature: 0.6,
 				max_tokens: 2048,
 			}))?.choices[0].message.content;


### PR DESCRIPTION
## What does this PR do?

- Use gpt-4o-mini instead of gpt-4o for PR reviewer

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## Any background context you want to provide beyond Shortcut?

[Slack thread](https://firefliesapp.slack.com/archives/CKZF9G804/p1722434094593639?thread_ts=1722374147.078179&cid=CKZF9G804)