### PR TITLE
refactor(auto_release): use PR title if "What does this PR do" is empty

### DIFF
--- a/.github/scripts/auto_release.js
+++ b/.github/scripts/auto_release.js
@@ -124,7 +124,9 @@ Computing summaries of merged PRs...
 			const pullRequest = allPullRequests[number];
 
 			let message = pullRequest.body.split('What does this PR do?')[1]?.split('#')[0]?.trim(); // Extract the PR summaries from the description body
-			if (!message) return draft;
+			if (!message) {
+				message = pullRequest.title;
+			}
 
 			isBugFix ||= /\[x\] Bugfix/gm.test(pullRequest.body)
 			isFeature ||= /\[x\] Feature/gm.test(pullRequest.body)


### PR DESCRIPTION
## What does this PR do?

### note

In a few simple PRs, the content of "What does this PR do" would be empty and PR title might be enough. 

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [x] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
