### PR TITLE
feat: try to handle Experimental Release Summary in Slack announce

### DIFF
--- a/.github/scripts/auto_announce.js
+++ b/.github/scripts/auto_announce.js
@@ -155,10 +155,18 @@ module.exports = {
 		}
 
 		console.info('Before Formatting: ', body);
-		body = body.replaceAll(/<![^<>]+>/g, ''); // Remove <!-- ... --> strings
-		body = body.replaceAll(/(\w|`)(\n|\r)+(\w|`)/g, '$1 $3'); // Remove unintentional line breaks between words and tilde
-		body = body.replaceAll(/\n\s+-/g, '\n-'); // Remove white space between line break and bullet
-		body = body.replaceAll(/\* (.+) (by .+) in (https:\/\/.+)(\n)*/g, '* [$1]($3) $2$4'); // Convert PR title to hyperlink
+		const summaries = body.split(`## Experimental Release Summary`);
+		for (let i=0; i< summaries.length; i++) {
+			summaries[i] = summaries[i].replaceAll(/<![^<>]+>/g, ''); // Remove <!-- ... --> strings
+			summaries[i] = summaries[i].replaceAll(/(\w|`)(\n|\r)+(\w|`)/g, '$1 $3'); // Remove unintentional line breaks between words and tilde
+			if (i==0) {
+				/** remove space can not apply on ## Experimental Release Summary since it would break nested list */
+				summaries[i] = summaries[i].replaceAll(/\n\s+-/g, '\n-'); // Remove white space between line break and bullet
+			}
+			summaries[i] = summaries[i].replaceAll(/\* (.+) (by .+) in (https:\/\/.+)(\n)*/g, '* [$1]($3) $2$4'); // Convert PR title to hyperlink
+		}
+		body = summaries.join(`## Experimental Release Summary`);
+
 		const [summary, changes] = body.split(`## What's Changed`); // Split summaries from changes
 
 		const { owner, repo } = context.repo;

--- a/.github/scripts/auto_release.js
+++ b/.github/scripts/auto_release.js
@@ -158,6 +158,7 @@ ${message}`;
 			draft += `
 			${summaryItem}`;
 		}, body);
+		console.debug("body after adding Experimental Release Summary", body)
 		/** End: experiment new Release Summary */
 
 		const releaseActions = getReleaseActions({ isFeature, isBugFix, isBreaking });
@@ -183,6 +184,8 @@ ${releaseActions.join('\n')}
 
 /** used by Experimental Release Summary */
 const processString = (bodyStr, titleStr) => {
+	console.debug("bodyStr of each PR in Experimental Release Summary", bodyStr)
+
 	// Case 2: If bodyStr length is less than or equal to 5, return titleStr
 	if (bodyStr.length <= 5) {
 	  return titleStr;
@@ -200,6 +203,7 @@ const processString = (bodyStr, titleStr) => {
 	  let [, preListContent, list] = listMatch;
 	  let firstWords = preListContent.trim();
 	  
+	  console.debug(`list:${list}, preListContent:${preListContent}; whole listMatch:`,  listMatch)
 	  // If there are no words before the list, use titleStr
 	  // This ensures we always have a title for the list
 	  if (!firstWords) {
@@ -222,6 +226,7 @@ const processString = (bodyStr, titleStr) => {
 		})
 		.join('\n');
 	  
+	  console.debug("organized pr content:"+ `\n- ${firstWords}\n${indentedList}`)
 	  // Note: Any text after the list is implicitly removed here,
 	  // as we only process the matched list items  
 	  return `\n- ${firstWords}\n${indentedList}`;


### PR DESCRIPTION
## What does this PR do?

### 

ref: https://firefliesapp.slack.com/archives/C0162DEUX08/p1726048049713849 the nested bullet/number list become flatterned due to its extra space is removed. 

Incorrect on slack release channel: 
```
Experimental Release Summary
•   Add openai structure format support in response format mode (in not function calling model), which only supports gpt-4o-mini-2024-07-18 and gpt-4o-2024-08-06 .
•   fix: summary leak to sentry
•   Fixes summary leak to sentry
```
should be 
```
Experimental Release Summary
•   Add openai structure format support in response format mode (in not function calling model), which only supports gpt-4o-mini-2024-07-18 and gpt-4o-2024-08-06 .
•   fix: summary leak to sentry
  •   Fixes summary leak to sentry
```

## Type of change

This pull request is a
- [ ] Feature
- [ ] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [ ] Non-breaking changes

## How should this be manually tested?

xxx

## What are the requirements to deploy to production?

<!--
  Please list the requirements to deploy to production.
  If there are no requirements, please delete this section.

  Example:
  - [ ] Add env variable to k8s-production
  - [ ] Run a script
  - [ ] Enable feature in growthbook
  - [ ] PR from x repo needs to be merged

-->

## Any background context you want to provide beyond Shortcut?

xxx

## Screenshots (if appropriate)

xxx

## Loom Video (if appropriate)

xxx

## Any Security implications

xxx
