### PR TITLE
Fix use fireflies bot token instead of github token to create releases

### DIFF
--- a/.github/workflows/gitflow-create-release.yml
+++ b/.github/workflows/gitflow-create-release.yml
@@ -6,17 +6,17 @@ on:
       develop_branch:
         required: true
         type: string
-        description: "Staging branch"
+        description: 'Staging branch'
 
       main_branch:
         required: true
         type: string
-        description: "Production branch"
+        description: 'Production branch'
 
       version:
         required: true
         type: string
-        description: "Version to release"
+        description: 'Version to release'
 
 jobs:
   create_release:
@@ -28,4 +28,4 @@ jobs:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FIREFLIES_BOT_TOKEN }}

--- a/.github/workflows/gitflow-post-release.yml
+++ b/.github/workflows/gitflow-post-release.yml
@@ -92,5 +92,5 @@ jobs:
               }
             }
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FIREFLIES_BOT_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/gitflow-release.yml
+++ b/.github/workflows/gitflow-release.yml
@@ -4,28 +4,28 @@ on:
       develop_branch:
         required: true
         type: string
-        description: "Staging branch"
+        description: 'Staging branch'
 
       main_branch:
         required: true
         type: string
-        description: "Production branch"
+        description: 'Production branch'
 
       version:
         required: false
         type: string
-        description: "Version to release"
+        description: 'Version to release'
 
       merge_back_from_main:
         required: false
         type: string
-        description: "Merge back from production branch instead of release branch to staging branch"
+        description: 'Merge back from production branch instead of release branch to staging branch'
 
       package_json_update_version:
         required: false
         default: false
         type: boolean
-        description: "Set to true to update package.json version to the release version"
+        description: 'Set to true to update package.json version to the release version'
 
 jobs:
   release:
@@ -37,9 +37,9 @@ jobs:
         with:
           develop_branch: ${{ inputs.develop_branch }}
           main_branch: ${{ inputs.main_branch }}
-          dry_run: "true"
+          dry_run: 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FIREFLIES_BOT_TOKEN }}
 
       - id: generate_pr_summary
         name: generate PR summary
@@ -184,7 +184,7 @@ jobs:
               }
             }
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FIREFLIES_BOT_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
 
       - uses: actions/checkout@v4 #check out to the release branch to bump package json version


### PR DESCRIPTION
## What does this PR do?

- Fix use fireflies bot token instead of github token to create releases

## Type of change

This pull request is a
- [ ] Feature
- [x] Bugfix
- [ ] Enhancement

Which introduces
- [ ] Breaking changes
- [x] Non-breaking changes

## Any background context you want to provide beyond Shortcut?

Some time github actions won't get triggered with github actions as it doesn't get triggered with bot actions, so using fireflies-bot token instead to resolve it

[Slack thread](https://firefliesapp.slack.com/archives/C01HXJE7BAS/p1727803500284519)